### PR TITLE
Fixed windows multicore greater than 1.

### DIFF
--- a/R/sits_classification.R
+++ b/R/sits_classification.R
@@ -110,7 +110,7 @@ sits_classify <- function(data        = NULL,
     if ("time_series" %in% names(data))
         result <- .sits_classify_ts(data, ml_model, interval, multicores)
     else
-        result <- .sits_classify_cube(data, ml_model, interval, filter, multicores, memsize, output_dir)
+        result <- .sits_classify_cube(data, ml_model, interval, filter, memsize, multicores, output_dir)
 
     return(result)
 }


### PR DESCRIPTION
Bug discovered after the SITS course at INPE 2019-09-13 (The multicore and memsize arguments were swapped). A long term solution is to always use named parameters on functions' arguments.
