### PR TITLE
Update test-data.R

### DIFF
--- a/tests/testthat/test-data.R
+++ b/tests/testthat/test-data.R
@@ -69,8 +69,8 @@ test_that("Reading a point from WTSS ", {
     timeline <- lubridate::as_date(as.vector(sits_time_series_dates(point.tb)))
 
     expect_true(ncol(sits_time_series(point.tb)) == 7)
-    expect_equal(sum(sits_time_series(point.tb)$evi),
-                 157.3737, tolerance = 1e-3)
+    expect_equal(sum(sits_time_series(point.tb)$evi[1:423]),                    
+                 157.3737, tolerance = 1e-3)  
     expect_true(point.tb$start_date == timeline[1])
     expect_true(point.tb$end_date == timeline[length(timeline)])
 })


### PR DESCRIPTION
This test will fail each time new images are added to the WTSS server. To avoid its failure, I constrained the sum to the length of the original time series [1:423].