### PR TITLE
Fixed bug due to the approximation (ceiling) of block_rows.

### DIFF
--- a/R/sits_raster.R
+++ b/R/sits_raster.R
@@ -56,7 +56,7 @@
     # nrow       Number of rows in the block extracted from the RasterBrick
     # size       size of each block in pixels
 
-    bs <- list(n = nblocks, row = row.vec, nrows = nrows.vec, size = size.vec)
+    bs <- list(n = length(row.vec), row = row.vec, nrows = nrows.vec, size = size.vec)
 
     return(bs)
 }


### PR DESCRIPTION
The approximation (ceiling) of the variable `block_rows` causes the classification of an additional (and nonexistent)  chunk of data, causing an error at the end of some classifications. 

To fix the error, this patch ensures that `n` and `row.vec` have the same size.