### PR TITLE
skip_on_cran removed from tests.

### DIFF
--- a/tests/testthat/test-active_learning.R
+++ b/tests/testthat/test-active_learning.R
@@ -59,7 +59,6 @@ test_that("Suggested samples have low confidence, high entropy", {
 })
 
 test_that("Increased samples have high confidence, low entropy", {
-    testthat::skip_on_cran()
 
     # Get uncertaintly cube.
     data_dir <- system.file("extdata/raster/mod13q1", package = "sits")


### PR DESCRIPTION
skip_on_cran removed from Active Learning tests.