### PR TITLE
Change sits_kfold_validade() multicores to 1 in Windows

### DIFF
--- a/R/sits_validate.R
+++ b/R/sits_validate.R
@@ -87,6 +87,17 @@ sits_kfold_validate <- function(samples,
         msg = "Invalid multicores parameter"
     )
 
+    # For now, torch models does not support multicores in Windows
+    if (multicores > 1 && .Platform$OS.type == "windows" &&
+        "optimizer" %in% ls(environment(ml_method))) {
+        multicores <- 1
+        warning(
+            "sits_kfold_validate() works only with 1 core in Windows OS.",
+            call. = FALSE,
+            immediate. = TRUE
+        )
+    }
+
     # get the labels of the data
     labels <- sits_labels(samples)
 


### PR DESCRIPTION
Torch models are raising error in Windows OS when multicores > 1 in `sits_kfold_validate()`
Closes #749 