### PR TITLE
Bug fixes

### DIFF
--- a/R/api_encode.R
+++ b/R/api_encode.R
@@ -381,7 +381,7 @@
         )
     })
     # Write blocks to file
-    embedding_bands <- .parallel_map(
+    .parallel_map(
         x = block_files,
         fn = .encode_merge_blocks,
         band_conf = band_conf,
@@ -389,7 +389,15 @@
         update_bbox = update_bbox,
         progress = FALSE
     )
-    embedding_tile <- dplyr::bind_rows(embedding_bands)
+    # Build a single tile with all embedding bands in one file_info
+    embedding_tile <- .tile_eo_from_files(
+        files = merge_out_files,
+        fid = .fi_fid(.fi(tile)),
+        bands = out_bands,
+        date = .tile_start_date(tile),
+        base_tile = tile,
+        update_bbox = update_bbox
+    )
 
     # Clean GPU memory allocation
     .ml_gpu_clean(encoder)
@@ -1113,7 +1121,7 @@
     })
     # No sits cluster in the streaming path: .parallel_map falls back to
     # sequential merging of the embedding bands
-    embedding_bands <- .parallel_map(
+    .parallel_map(
         x = block_files,
         fn = .encode_merge_blocks,
         band_conf = band_conf,
@@ -1121,7 +1129,15 @@
         update_bbox = update_bbox,
         progress = FALSE
     )
-    embedding_tile <- dplyr::bind_rows(embedding_bands)
+    # Build a single tile with all embedding bands in one file_info
+    embedding_tile <- .tile_eo_from_files(
+        files = merge_out_files,
+        fid = .fi_fid(.fi(tile)),
+        bands = out_bands,
+        date = .tile_start_date(tile),
+        base_tile = tile,
+        update_bbox = update_bbox
+    )
 
     # Clean GPU memory allocation
     .ml_gpu_clean(encoder)

--- a/R/api_file_info.R
+++ b/R/api_file_info.R
@@ -67,17 +67,18 @@ NULL
 .fi_eo <- function(fid, band, date, ncols, nrows, xres, yres, xmin, xmax,
                    ymin, ymax, crs, path) {
     # Create a new eo file_info
+    # Column order must match the file_info built by .local_cube_file_info()
     tibble::tibble(
         fid = fid,
         band = .band_eo(band),
         date = date,
-        ncols = ncols,
         nrows = nrows,
+        ncols = ncols,
         xres = xres,
         yres = yres,
         xmin = xmin,
-        xmax = xmax,
         ymin = ymin,
+        xmax = xmax,
         ymax = ymax,
         crs = crs,
         path = path
@@ -96,7 +97,7 @@ NULL
     .check_that(length(files) == length(bands))
     files <- .file_path_expand(files)
     rast <- .raster_open_rast(files)
-    .fi_eo(
+    fi <- .fi_eo(
         fid = fid[[1L]],
         band = bands,
         date = date[[1L]],
@@ -111,6 +112,8 @@ NULL
         crs = .raster_crs(rast),
         path = files
     )
+    # Row order must match the file_info built by .local_cube_file_info()
+    dplyr::arrange(fi, .data[["date"]], .data[["band"]])
 }
 #' @title Create a file_info for a new derived_cube
 #' @noRd

--- a/R/sits_encode.R
+++ b/R/sits_encode.R
@@ -452,21 +452,6 @@ sits_encode.raster_cube <- function(data,
             )
         }
     })
-    # Fix to resolve bug in encoding
-    #
-    emb_cube <- .local_raster_cube(
-        source = .cube_source(data),
-        collection = .cube_collection(data),
-        data_dir = output_dir,
-        parse_info = c("X1", "X2", "tile", "band", "date"),
-        delim = "_",
-        tiles = .cube_tiles(data),
-        bands = .cube_bands(emb_cube),
-        start_date = start_date,
-        end_date = end_date,
-        multicores = multicores,
-        progress = progress, ...
-    )
     .cube_set_class(emb_cube, c("embeddings_cube", class(emb_cube)))
 }
 

--- a/man/sits-package.Rd
+++ b/man/sits-package.Rd
@@ -58,6 +58,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Gilberto Camara \email{gilberto.camara.inpe@gmail.com} [thesis advisor]
   \item Rolf Simoes \email{rolfsimoes@gmail.com}
   \item Felipe Souza \email{felipe.carvalho@inpe.br}
   \item Felipe Carlos \email{efelipecarlos@gmail.com}

--- a/tests/testthat/test-encode.R
+++ b/tests/testthat/test-encode.R
@@ -1,0 +1,147 @@
+# Structure tests for raster-cube encoding. Every encode path must return
+# the same cube structure that sits_cube() builds from the output files:
+# one cube row per tile, with all embedding bands in that row's file_info
+# (canonical column and row order of .local_cube_file_info).
+
+# Rebuild the encoder output as a local cube: the reference structure.
+# sits_cube() classes it as embeddings_cube on its own (all bands EMB*)
+encode_ref_cube <- function(output_dir) {
+    sits_cube(
+        source = "BDC",
+        collection = "MOD13Q1-6.1",
+        data_dir = output_dir,
+        parse_info = c("X1", "X2", "tile", "band", "date"),
+        delim = "_",
+        progress = FALSE
+    )
+}
+
+# The embeddings_cube class is added by the public sits_encode() wrapper,
+# not by the tile functions; align tile results the same way
+encode_as_emb <- function(tile) {
+    .cube_set_class(tile, c("embeddings_cube", class(tile)))
+}
+
+# Cheap pre-trained encoder; embedding_dim >= 10 so band names reach two
+# digits (EMB10...) and row ordering is actually discriminated
+encode_test_encoder <- function() {
+    .try(
+        sits_pre_train(
+            samples        = samples_modis_ndvi,
+            encoder_method = sits_ssl_mae(
+                embedding_dim  = 12L,
+                decoder_width  = 32L,
+                mask_ratio     = 0.5,
+                epochs         = 2L,
+                batch_size     = 32L,
+                verbose        = FALSE
+            )
+        ),
+        .default = NULL
+    )
+}
+
+test_that("cube encoding returns the same structure as sits_cube()", {
+    skip_on_cran()
+    skip_if_not_installed("torch")
+    skip_if_not_installed("luz")
+
+    set.seed(42)
+    torch::torch_manual_seed(42)
+    encoder <- encode_test_encoder()
+    skip_if(is.null(encoder), "torch training failed")
+
+    cube <- sits_cube(
+        source = "BDC",
+        collection = "MOD13Q1-6.1",
+        data_dir = system.file("extdata/raster/mod13q1", package = "sits"),
+        progress = FALSE
+    )
+    tile <- .tile(cube)
+    out_bands <- .encode_band_names(encoder)
+    # several chunks so block merging is actually exercised
+    block <- c(ncols = 255L, nrows = 50L)
+    sits_env[["batch_size"]] <- 32L
+
+    cpu_dir <- file.path(tempdir(), "encode_struct_cpu")
+    gpu_dir <- file.path(tempdir(), "encode_struct_gpu")
+    pub_dir <- file.path(tempdir(), "encode_struct_pub")
+    unlink(c(cpu_dir, gpu_dir, pub_dir), recursive = TRUE)
+    dir.create(cpu_dir)
+    dir.create(gpu_dir)
+    dir.create(pub_dir)
+    on.exit(unlink(c(cpu_dir, gpu_dir, pub_dir), recursive = TRUE),
+        add = TRUE
+    )
+
+    emb_cpu <- .encode_tile_cpu(
+        tile = tile, out_bands = out_bands, bands = "NDVI",
+        base_bands = NULL, encoder = encoder, block = block, roi = NULL,
+        impute_fn = impute_linear(), output_dir = cpu_dir,
+        verbose = FALSE, progress = FALSE
+    )
+    expect_equal(nrow(emb_cpu), 1L)
+    expect_equal(nrow(emb_cpu$file_info[[1L]]), 12L)
+    expect_equal(encode_as_emb(emb_cpu), encode_ref_cube(cpu_dir))
+
+    # direct call: dispatch via sits_encode() requires a GPU device,
+    # but the tile structure under test is device-agnostic
+    .torch_model_to_device(encoder)
+    emb_gpu <- .encode_tile_gpu(
+        tile = tile, out_bands = out_bands, bands = "NDVI",
+        base_bands = NULL, encoder = encoder, block = block, roi = NULL,
+        impute_fn = impute_linear(), output_dir = gpu_dir,
+        verbose = FALSE, progress = FALSE
+    )
+    expect_equal(nrow(emb_gpu), 1L)
+    expect_equal(nrow(emb_gpu$file_info[[1L]]), 12L)
+    expect_equal(encode_as_emb(emb_gpu), encode_ref_cube(gpu_dir))
+
+    emb <- sits_encode(
+        data = cube, encoder = encoder, memsize = 4L, multicores = 2L,
+        output_dir = pub_dir, progress = FALSE
+    )
+    expect_s3_class(emb, "embeddings_cube")
+    expect_equal(emb, encode_ref_cube(pub_dir))
+})
+
+test_that("streaming encoding returns the same structure as sits_cube()", {
+    # NOTE: run against an *installed* dev sits. Stage closures are
+    # serialized to workers with a namespace reference, so workers resolve
+    # sits internals in the installed package; under pkgload::load_all()
+    # over an older installed sits, workers execute mixed code.
+    skip_on_cran()
+    skip_if_not_installed("siphon")
+    skip_if_not_installed("torch")
+    skip_if_not_installed("luz")
+
+    set.seed(42)
+    torch::torch_manual_seed(42)
+    encoder <- encode_test_encoder()
+    skip_if(is.null(encoder), "torch training failed")
+
+    cube <- sits_cube(
+        source = "BDC",
+        collection = "MOD13Q1-6.1",
+        data_dir = system.file("extdata/raster/mod13q1", package = "sits"),
+        progress = FALSE
+    )
+    tile <- .tile(cube)
+    sits_env[["batch_size"]] <- 32L
+
+    stream_dir <- file.path(tempdir(), "encode_struct_stream")
+    unlink(stream_dir, recursive = TRUE)
+    dir.create(stream_dir)
+    on.exit(unlink(stream_dir, recursive = TRUE), add = TRUE)
+
+    emb_stream <- .encode_tile_stream(
+        tile = tile, out_bands = .encode_band_names(encoder),
+        bands = "NDVI", base_bands = NULL, encoder = encoder,
+        block = c(ncols = 255L, nrows = 50L), roi = NULL,
+        impute_fn = impute_linear(), output_dir = stream_dir,
+        multicores = 2L, verbose = FALSE, progress = FALSE
+    )
+    expect_equal(nrow(emb_stream), 1L)
+    expect_equal(nrow(emb_stream$file_info[[1L]]), 12L)
+    expect_equal(encode_as_emb(emb_stream), encode_ref_cube(stream_dir))
+})

--- a/tests/testthat/test-raster.R
+++ b/tests/testthat/test-raster.R
@@ -42,6 +42,9 @@ test_that("Embeddings plus classification with rfor", {
     )
     expect_equal(length(sits_bands(sinop_emb)), 12)
     expect_equal(sits_timeline(sinop_emb), as.Date("2013-09-14"))
+    # one cube row per tile, all embedding bands in its file_info
+    expect_equal(nrow(sinop_emb), nrow(sinop))
+    expect_equal(nrow(sinop_emb$file_info[[1]]), 12)
     samples_emb <- sits_encode(
         data = samples_modis_ndvi,
         encoder = mae_model


### PR DESCRIPTION
The `sits_encode()` metadata bug caused the GPU and streaming encode paths to build the cube with one row per embedding band instead of one row per tile with all bands in the `file_info`.

New tests:
- [test-encode.R](cci:7://file:///home/rolf/gh/sits/tests/testthat/test-encode.R:0:0-0:0): calls `.encode_tile_cpu/gpu/stream` directly and compares each result with `sits_cube()` on the generated files.
- `test-classify-stream.R`: covers streaming classification that is pixel-identical to CPU and persistent cluster reuse.